### PR TITLE
Move application logic to separate file

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -1,0 +1,49 @@
+import os
+import logging
+
+from neo4j import GraphDatabase, Query, Record
+from neo4j.exceptions import ServiceUnavailable
+
+from utils import read_config
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def run(output_dir, neo4j_config):
+    # Get Neo4j credentials from config
+    neo4j_credentials = neo4j_config.get("neo4j_credentials", {})
+    NEO4J_URI = neo4j_credentials.get("NEO4J_URI", "")
+    NEO4J_USERNAME = neo4j_credentials.get("NEO4J_USERNAME", "")
+    NEO4J_PASSWORD = neo4j_credentials.get("NEO4J_PASSWORD", "")
+    NEO4J_DB = neo4j_credentials.get("NEO4J_DB", "")
+    logger.info(f"Neo4j Connect to {NEO4J_URI} using {NEO4J_USERNAME}")
+
+    # Driver instantiation
+    driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
+
+    # Create a driver session with defined DB
+    with driver.session(database=NEO4J_DB) as session:
+
+        # Example Query to Count Nodes
+        node_count_query = "MATCH (n) RETURN count(n)"
+
+        # Use .data() to access the results array
+        results = session.run(node_count_query).data()
+        logger.info(results)
+
+    with open(os.path.join(output_dir, 'results.txt'), 'w') as text_file:
+        text_file.write(f"{results}")
+
+    # Close the driver connection
+    driver.close()
+
+if __name__ == "__main__":
+    import sys
+    output_dir = 'data/output'
+    config_path = 'config.yml'
+    if len(sys.argv) > 1:
+        output_dir = sys.argv[1]
+    if len(sys.argv) > 2:
+        config_path = sys.argv[2]
+    config = read_config(config_path)
+    run(output_dir, config)

--- a/app/states.py
+++ b/app/states.py
@@ -1,20 +1,14 @@
 from FeatureCloud.app.engine.app import AppState, app_state, Role
 import time
 import os
-import logging
 
-from neo4j import GraphDatabase, Query, Record
-from neo4j.exceptions import ServiceUnavailable
 from pandas import DataFrame
 
-from utils import read_config,write_output
+from run import run
+from utils import read_config
 
-from FeatureCloud.app.engine.app import AppState, app_state
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-
-config = read_config()
+INPUT_DIR='/mnt/input'
+OUTPUT_DIR='/mnt/output'
 
 @app_state('initial')
 class ExecuteState(AppState):
@@ -22,36 +16,6 @@ class ExecuteState(AppState):
     def register(self):
         self.register_transition('terminal', Role.BOTH)
 
-        
     def run(self):
-        
-        # Get Neo4j credentials from config
-        neo4j_credentials = config.get("neo4j_credentials", {})
-        NEO4J_URI = neo4j_credentials.get("NEO4J_URI", "")
-        NEO4J_USERNAME = neo4j_credentials.get("NEO4J_USERNAME", "")
-        NEO4J_PASSWORD = neo4j_credentials.get("NEO4J_PASSWORD", "")
-        NEO4J_DB = neo4j_credentials.get("NEO4J_DB", "")
-        logger.info(f"Neo4j Connect to {NEO4J_URI} using {NEO4J_USERNAME}")
-        
-        # Driver instantiation
-        driver = GraphDatabase.driver(NEO4J_URI, auth=(NEO4J_USERNAME, NEO4J_PASSWORD))
-        
-        # Create a driver session with defined DB
-        with driver.session(database=NEO4J_DB) as session:
-                
-            # Example Query to Count Nodes 
-            node_count_query = "MATCH (n) RETURN count(n)"
-        
-            # Use .data() to access the results array        
-            results = session.run(node_count_query).data()
-            logger.info(results)
-            
-        write_output(f"{results}")
-
-        # Close the driver connection
-        driver.close()
-
+        run(output_dir=OUTPUT_DIR, neo4j_config=read_config(f'{INPUT_DIR}/config.yml'))
         return 'terminal'
-
-
-

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,24 +5,10 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-INPUT_DIR = '/mnt/input'
-OUTPUT_DIR = '/mnt/output'
-
-def read_config(file_path=f"{INPUT_DIR}/config.yml"):
-    try:
-        with open(file_path, "r") as config_file:
-            config = yaml.safe_load(config_file)
-        return config
-                
-    except FileNotFoundError:
-        logger.info(f"Config file '{file_path}' not found.")
-
-
-def write_output(content, file_path=f"{OUTPUT_DIR}/results.txt"):
-    
-    with open(file_path, "w") as text_file:
-        text_file.write(content)
-
+def read_config(file_path):
+    with open(file_path, "r") as config_file:
+        config = yaml.safe_load(config_file)
+    return config
 
 def convert_to_np(data):
     if isinstance(data, (pd.Series, pd.DataFrame)):


### PR DESCRIPTION
Put application logic in a separate file from the server logic. This allows the application logic to be run separately without Docker or Nginx, for easier development.